### PR TITLE
Switch to Parse for the backend

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     }
   },
   "dependencies": {
+    "parse": "^1.9.2",
     "vue": "^2.2.1",
     "vue-material": "^0.7.1",
     "vue-router": "^2.3.0",

--- a/src/components/LoginForm.vue
+++ b/src/components/LoginForm.vue
@@ -5,9 +5,9 @@
     <form id="login-form"v-on:submit.prevent="handleSubmit">
       <h2>Dashboard Sign In</h2>
 
-      <md-input-container :class="{ 'md-input-invalid': emailError }">
-        <label>Email</label>
-        <md-input type="email" v-model="email"></md-input>
+      <md-input-container :class="{ 'md-input-invalid': usernameError }">
+        <label>Username</label>
+        <md-input type="text" v-model="username"></md-input>
       </md-input-container>
 
       <md-input-container :class="{'md-input-invalid': passwordError }">
@@ -50,24 +50,24 @@
 
     data() {
       return {
-        email: '',
+        username: '',
         password: '',
-        emailError: false,
+        usernameError: false,
         passwordError: false,
       };
     },
 
     methods: {
       resetErrors() {
-        this.emailError = false;
+        this.usernameError = false;
         this.passwordError = false;
       },
       handleSubmit() {
         let hasErrors = false;
         this.resetErrors();
 
-        if (!this.email || this.email.length < 1) {
-          this.emailError = true;
+        if (!this.username || this.username.length < 1) {
+          this.usernameError = true;
           hasErrors = true;
         }
 
@@ -78,8 +78,8 @@
 
         if (hasErrors) return;
 
-        const { email, password } = this;
-        this.onSubmit({ email, password });
+        const { username, password } = this;
+        this.onSubmit({ username, password });
       },
     },
   };

--- a/src/components/SignupForm.vue
+++ b/src/components/SignupForm.vue
@@ -15,6 +15,10 @@
         <input type="email" v-model="email">
       </div>
       <div>
+        <label>username</label>
+        <input type="text" v-model="username">
+      </div>
+      <div>
         <label>password</label>
         <input type="password" v-model="password">
       </div>
@@ -37,6 +41,7 @@
     name: 'signup-form',
     data() {
       return {
+        username: '',
         email: '',
         password: '',
         passwordConfirm: '',
@@ -51,8 +56,8 @@
     },
     methods: {
       doSubmit() {
-        const { email, password, passwordConfirm, firstName, lastName, onSubmit } = this;
-        this.onSubmit({ email, password, passwordConfirm, firstName, lastName, onSubmit });
+        const { username, email, password, passwordConfirm, firstName, lastName, onSubmit } = this;
+        this.onSubmit({ username, email, password, passwordConfirm, firstName, lastName, onSubmit });
       },
     },
   };

--- a/src/lib/parse.js
+++ b/src/lib/parse.js
@@ -1,0 +1,7 @@
+import parse from 'parse';
+
+parse.initialize('eb2c1139-b8bd-4f30-8c8c-8856debef042');
+// parse.javascriptKey = '4hsr5gHTorMGuZ3F4xN9WI3RfPJtJ08d';
+parse.serverURL = 'https://parse.buddy.com/parse';
+
+export default parse;

--- a/src/main.js
+++ b/src/main.js
@@ -4,6 +4,9 @@ import VueMaterial from 'vue-material';
 import 'vue-material/dist/vue-material.css';
 import router from './router';
 import store from './store';
+import parse from './lib/parse';
+
+window.parse = parse;
 
 Vue.use(VueMaterial);
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -725,7 +725,7 @@ babel-register@^6.24.0:
     mkdirp "^0.5.1"
     source-map-support "^0.4.2"
 
-babel-runtime@^6.18.0, babel-runtime@^6.22.0:
+babel-runtime@^6.11.6, babel-runtime@^6.18.0, babel-runtime@^6.22.0:
   version "6.23.0"
   resolved "https://registry.yarnpkg.com/babel-runtime/-/babel-runtime-6.23.0.tgz#0a9489f144de70efb3ce4300accdb329e2fc543b"
   dependencies:
@@ -3785,6 +3785,10 @@ optionator@^0.8.1, optionator@^0.8.2:
     type-check "~0.3.2"
     wordwrap "~1.0.0"
 
+options@>=0.0.5:
+  version "0.0.6"
+  resolved "https://registry.yarnpkg.com/options/-/options-0.0.6.tgz#ec22d312806bb53e731773e7cdaefcf1c643128f"
+
 original@>=0.0.5:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/original/-/original-1.0.0.tgz#9147f93fa1696d04be61e01bd50baeaca656bd3b"
@@ -3864,6 +3868,14 @@ parse-json@^2.2.0:
 parse5@^1.5.1:
   version "1.5.1"
   resolved "https://registry.yarnpkg.com/parse5/-/parse5-1.5.1.tgz#9b7f3b0de32be78dc2401b17573ccaf0f6f59d94"
+
+parse@^1.9.2:
+  version "1.9.2"
+  resolved "https://registry.yarnpkg.com/parse/-/parse-1.9.2.tgz#e41d7cb6efd464eea30c34ec0651548f66c5b8e4"
+  dependencies:
+    babel-runtime "^6.11.6"
+    ws "^1.0.1"
+    xmlhttprequest "^1.7.0"
 
 parseurl@~1.3.1:
   version "1.3.1"
@@ -5128,6 +5140,10 @@ uid-number@^0.0.6:
   version "0.0.6"
   resolved "https://registry.yarnpkg.com/uid-number/-/uid-number-0.0.6.tgz#0ea10e8035e8eb5b8e4449f06da1c730663baa81"
 
+ultron@1.0.x:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/ultron/-/ultron-1.0.2.tgz#ace116ab557cd197386a4e88f4685378c8b2e4fa"
+
 uniq@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/uniq/-/uniq-1.0.1.tgz#b31c5ae8254844a3a8281541ce2b04b865a734ff"
@@ -5482,6 +5498,13 @@ write@^0.2.1:
   dependencies:
     mkdirp "^0.5.1"
 
+ws@^1.0.1:
+  version "1.1.4"
+  resolved "https://registry.yarnpkg.com/ws/-/ws-1.1.4.tgz#57f40d036832e5f5055662a397c4de76ed66bf61"
+  dependencies:
+    options ">=0.0.5"
+    ultron "1.0.x"
+
 xml-char-classes@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/xml-char-classes/-/xml-char-classes-1.0.0.tgz#64657848a20ffc5df583a42ad8a277b4512bbc4d"
@@ -5489,6 +5512,10 @@ xml-char-classes@^1.0.0:
 xml-name-validator@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/xml-name-validator/-/xml-name-validator-2.0.1.tgz#4d8b8f1eccd3419aa362061becef515e1e559635"
+
+xmlhttprequest@^1.7.0:
+  version "1.8.0"
+  resolved "https://registry.yarnpkg.com/xmlhttprequest/-/xmlhttprequest-1.8.0.tgz#67fe075c5c24fef39f9d65f5f7b7fe75171968fc"
 
 "xtend@>=4.0.0 <4.1.0-0", xtend@^4.0.0:
   version "4.0.1"


### PR DESCRIPTION
Backand user accounts have gotten really annoying, their data querying doesn't work the way I thought it would, and I'm still not at all sure how user access works.

I think Parse might work better. https://parse.buddy.com is another free option, with the same generous billing terms as the original Parse service. No user limits, really easy API, and I think pretty east ACL stuff... still gotta read up on that one though. Best of all, since Parse is open source, and many people have hosting plans with it, if Buddy goes away, data can be migrated, or a custom server could be created.

This PR changes the authorization store, login, logout, and signup stuff (the latter isn't actually used).

Possibly helpful for future reference: [Parse docs](http://docs.parseplatform.org/js/guide/#getting-started)