### PR TITLE
Allow admins to modify user

### DIFF
--- a/src/components/EditUser.vue
+++ b/src/components/EditUser.vue
@@ -64,8 +64,6 @@
 <script>
   import { update as updateUser } from '../services/members';
 
-  const chars = 'abcdefghijklmnopqrstuvwxyzABCDEFGHJKLMNPRTUVWXYZ1234567890';
-
   export default {
     name: 'edit-user',
     data: () => ({
@@ -89,7 +87,7 @@
         return updateUser(this.user.id, this.tempUser)
         .then(() => {
           this.savePending = false;
-          this.closeDialog();
+          this.$emit('close');
         })
         .catch((err) => {
           this.savePending = false;

--- a/src/components/EditUser.vue
+++ b/src/components/EditUser.vue
@@ -4,7 +4,7 @@
       <md-dialog-title>Edit user {{user.username}}</md-dialog-title>
 
       <md-dialog-content>
-        <md-layout md-gutter>
+        <md-layout md-gutter="16">
           <md-layout md-flex="50">
 
             <md-input-container>
@@ -62,7 +62,7 @@
 </template>
 
 <script>
-  import { update as updateUser } from '../services/user';
+  import { update as updateUser } from '../services/members';
 
   const chars = 'abcdefghijklmnopqrstuvwxyzABCDEFGHJKLMNPRTUVWXYZ1234567890';
 
@@ -79,14 +79,22 @@
     },
     methods: {
       closeDialog() {
-        this.$refs.editUser && this.$refs.editUser.close();
+        this.$refs.editUser.close();
       },
       openDialog() {
-        this.$refs.editUser && this.$refs.editUser.open();
+        this.$refs.editUser.open();
       },
       doSaveUser() {
-        // updateUser
-        console.log('save user', this.tempUser);
+        this.savePending = true;
+        return updateUser(this.user.id, this.tempUser)
+        .then(() => {
+          this.savePending = false;
+          this.closeDialog();
+        })
+        .catch((err) => {
+          this.savePending = false;
+          this.alert = err.message || 'Save failed :(';
+        });
       },
     },
     watch: {

--- a/src/components/EditUser.vue
+++ b/src/components/EditUser.vue
@@ -1,0 +1,105 @@
+<template>
+  <md-dialog ref="editUser" :md-esc-to-close="false" :md-click-outside-to-close="false">
+    <form @submit.prevent="doSaveUser" v-if="user">
+      <md-dialog-title>Edit user {{user.username}}</md-dialog-title>
+
+      <md-dialog-content>
+        <md-layout md-gutter>
+          <md-layout md-flex="50">
+
+            <md-input-container>
+              <label>Email</label>
+              <md-input v-model="tempUser.email"></md-input>
+            </md-input-container>
+            <md-input-container>
+              <label>First Name</label>
+              <md-input v-model="tempUser.firstName"></md-input>
+            </md-input-container>
+            <md-input-container>
+              <label>Last Name</label>
+              <md-input v-model="tempUser.lastName"></md-input>
+            </md-input-container>
+
+            <!-- onboarding info -->
+            <div class="md-chips">
+              <md-chip v-if="tempUser.commitmentAgreementSigned">Agreement Signed</md-chip>
+              <md-chip v-if="tempUser.ndaSigned">Confidentiality Signed</md-chip>
+              <md-chip v-if="tempUser.solutioneer101Passed">Solutioneering 101 Passed</md-chip>
+            </div>
+            <!-- <md-chip>Projects Selected</md-chip> -->
+
+          </md-layout>
+          <md-layout>
+
+            <md-input-container>
+              <label>Chapter</label>
+              <md-input v-model="tempUser.chapter"></md-input>
+            </md-input-container>
+            <md-input-container>
+              <label>Position</label>
+              <md-input v-model="tempUser.position"></md-input>
+            </md-input-container>
+            <md-input-container>
+              <label>Semester Joined</label>
+              <md-input v-model="tempUser.semesterJoined"></md-input>
+            </md-input-container>
+
+          </md-layout>
+        </md-layout>
+
+        <p style="color: red;" v-if="alert.length">
+          <md-icon>error_output</md-icon>
+          {{ alert }}
+        </p>
+      </md-dialog-content>
+
+      <md-dialog-actions>
+        <md-button type="reset" @click.native.prevent="$emit('close')">Cancel</md-button>
+        <md-button class="md-raised md-primary" type="submit" :disabled="savePending">Save Changes</md-button>
+      </md-dialog-actions>
+    </form>
+  </md-dialog>
+</template>
+
+<script>
+  import { update as updateUser } from '../services/user';
+
+  const chars = 'abcdefghijklmnopqrstuvwxyzABCDEFGHJKLMNPRTUVWXYZ1234567890';
+
+  export default {
+    name: 'edit-user',
+    data: () => ({
+      tempUser: {},
+      alert: '',
+      savePending: false,
+    }),
+    props: {
+      isOpen: false,
+      user: Object,
+    },
+    methods: {
+      closeDialog() {
+        this.$refs.editUser && this.$refs.editUser.close();
+      },
+      openDialog() {
+        this.$refs.editUser && this.$refs.editUser.open();
+      },
+      doSaveUser() {
+        // updateUser
+        console.log('save user', this.tempUser);
+      },
+    },
+    watch: {
+      isOpen(val) {
+        if (val) this.openDialog();
+        else this.closeDialog();
+      },
+      user(userObj) {
+        this.tempUser = { ...userObj };
+      },
+    },
+    mounted() {
+      if (this.isOpen) this.openDialog();
+    },
+  };
+</script>

--- a/src/models/parse_object.js
+++ b/src/models/parse_object.js
@@ -1,0 +1,10 @@
+export default class ParseObject {
+  toJSON() {
+    const keys = Object.getOwnPropertyNames(Object.getPrototypeOf(this));
+
+    return keys.reduce((acc, key) => {
+      if (typeof this[key] !== 'function') acc[key] = this[key];
+      return acc;
+    }, {});
+  }
+}

--- a/src/models/project.js
+++ b/src/models/project.js
@@ -1,8 +1,10 @@
 import moment from 'moment';
 import parse from '../lib/parse';
+import ParseObject from './parse_object';
 
-export default class Project {
+export default class Project extends ParseObject {
   constructor(project) {
+    super();
     this.project = project || new parse.Project();
   }
 

--- a/src/models/user.js
+++ b/src/models/user.js
@@ -1,9 +1,10 @@
 import moment from 'moment';
 import parse from '../lib/parse';
+import ParseObject from './parse_object';
 
-
-export default class User {
+export default class User extends ParseObject {
   constructor(user) {
+    super();
     this.user = user || new parse.User();
   }
 

--- a/src/pages/admin/MemberList.vue
+++ b/src/pages/admin/MemberList.vue
@@ -192,6 +192,7 @@ export default {
     },
     closeEditUser() {
       this.showEditUser = false;
+      this.refreshMembers();
     },
   },
 };

--- a/src/pages/admin/MemberList.vue
+++ b/src/pages/admin/MemberList.vue
@@ -2,6 +2,7 @@
   <div>
     <!-- add user dialog -->
     <add-user :is-open="showAddUser" @close="closeAddUser" @create="refreshMembers"></add-user>
+    <edit-user :is-open="showEditUser" :user="selectedUser" @close="closeEditUser"></edit-user>
 
     <form @submit.prevent="refreshMembers">
       <md-toolbar class="md-transparent">
@@ -58,6 +59,9 @@
           <md-table-cell>{{ member.chapter }}</md-table-cell>
           <md-table-cell>{{ member.position }}</md-table-cell>
           <md-table-cell>{{ member.semesterJoined }}</md-table-cell>
+          <md-table-cell>
+            <md-icon @click.native="openEditUser(member)">edit</md-icon>
+          </md-table-cell>
         </md-table-row>
         <md-table-row v-if="pageMembers.length < filters.perPage" v-for="num in (filters.perPage - pageMembers.length)" :key="'_empty'+num">
           <md-table-cell></md-table-cell>
@@ -86,6 +90,7 @@
 <script>
 import { mapState, mapActions } from 'vuex';
 import AddUser from '../../components/AddUser.vue';
+import EditUser from '../../components/EditUser.vue';
 
 const ucFirst = str => str.substring(0, 1).toUpperCase() + str.substring(1).toLowerCase();
 
@@ -93,10 +98,15 @@ export default {
   name: 'admin-member-list-page',
   components: {
     AddUser,
+    EditUser,
   },
   data: () => ({
     searchInput: '',
     showAddUser: false,
+
+    showEditUser: false,
+    selectedUser: null,
+
     filters: {
       perPage: 20,
       currentPage: 1,
@@ -175,6 +185,13 @@ export default {
     },
     closeAddUser() {
       this.showAddUser = false;
+    },
+    openEditUser(user) {
+      this.selectedUser = user.toJSON();
+      this.showEditUser = true;
+    },
+    closeEditUser() {
+      this.showEditUser = false;
     },
   },
 };

--- a/src/services/members.js
+++ b/src/services/members.js
@@ -35,7 +35,7 @@ export function update(id, data) {
       if (blacklisted.indexOf(prop) < 0) member[prop] = data[prop];
     });
 
-    return member.save();
+    return member.save().then(() => member);
   });
 }
 

--- a/src/services/members.js
+++ b/src/services/members.js
@@ -1,3 +1,4 @@
+/* eslint no-param-reassign: 0 */
 import { isPlainObject } from '../lib/utils';
 import parse from '../lib/parse';
 import queryBuilder from '../lib/query_builder';
@@ -16,9 +17,26 @@ export function getById(id) {
 export function update(id, data) {
   if (!isPlainObject(data)) return Promise.reject('data must be an object');
 
-  const member = typeof id === 'string' ? getById(id) : id;
-  Object.keys(data).forEach(prop => (member[prop] = data[prop]));
-  return member.save();
+  const getMember = typeof id === 'string' ? getById(id) : Promise.resolve(id);
+
+  return getMember
+  .then((member) => {
+    Object.keys(data).forEach((prop) => {
+      // don't update some fields
+      const blacklisted = [
+        'id',
+        'password',
+        'createdAt',
+        'updatedAt',
+        'fullName',
+        'isOnboarded',
+      ];
+
+      if (blacklisted.indexOf(prop) < 0) member[prop] = data[prop];
+    });
+
+    return member.save();
+  });
 }
 
 export function setActive(user, active) {


### PR DESCRIPTION
- Add edit screen
- Add `toJSON` to model objects (useful for cloning or otherwise iterating model objects)

**NOTE**: This doesn't actually work, parse users can't update other user records. We might be able to work around it with the ACL stuff, or we might have to break the User fields out into another table... more research is needed.