### PR TITLE
Fix dashboard onboarding and login flow

### DIFF
--- a/src/models/member.js
+++ b/src/models/member.js
@@ -32,6 +32,17 @@ export default class Member extends ParseObject {
     this.instance.set('user', this.user);
     return this.instance.save();
   }
+
+  static fromUser(user) {
+    const parseUser = new parse.User();
+    parseUser.id = user.id;
+
+    const query = new parse.Query('Member');
+    query.include('user'); // hydrate the user property
+    query.equalTo('user', parseUser);
+
+    return query.first().then(member => member && new Member(member));
+  }
 }
 
 export const wrapMember = member => new Member(member);

--- a/src/models/user.js
+++ b/src/models/user.js
@@ -43,21 +43,33 @@ export default class User extends ParseObject {
   get ndaSignedDate() { return this.instance.get('ndaSignedDate'); }
   set ndaSignedDate(val) { return this.instance.set('ndaSignedDate', moment(val).utc().toDate()); }
 
-  static create() {
+  static create(wrap = true) {
     const user = new parse.User();
-    return user.signUp(null);
+    return user.signUp(null)
+    .then((newUser) => {
+      if (!wrap) return newUser;
+      return newUser && wrapUser(newUser); // eslint-disable-line no-use-before-define,max-len
+    });
   }
 
-  static login(username, password) {
-    return parse.User.logIn(username, password);
+  static login(username, password, wrap = true) {
+    return parse.User.logIn(username, password)
+    .then((user) => {
+      if (!wrap) return user;
+      return user && wrapUser(user); // eslint-disable-line no-use-before-define,max-len
+    });
   }
 
   static logout() {
     return parse.User.logOut();
   }
 
-  static getCurrent() {
-    return parse.User.current();
+  static getCurrent(wrap = true) {
+    const current = parse.User.current();
+
+    if (current && !wrap) return Promise.resolve(current);
+    if (current) return Promise.resolve(wrapUser(current)); // eslint-disable-line no-use-before-define,max-len
+    return Promise.resolve(null);
   }
 }
 

--- a/src/pages/CommitmentAgreement.vue
+++ b/src/pages/CommitmentAgreement.vue
@@ -46,7 +46,7 @@ export default {
     AgreementSignatureForm,
     FormError,
   },
-  mounted() {
+  created() {
     if (this.user.commitmentAgreementSigned) this.$router.replace({ name: 'solutioneering-101' });
   },
   data() {

--- a/src/pages/CommitmentAgreement.vue
+++ b/src/pages/CommitmentAgreement.vue
@@ -5,7 +5,7 @@
         <div class="md-title">Commitment Agreement</div>
       </md-card-header-text>
     </md-card-header>
-  
+
     <md-card-content>
       <p>Welcome to GreenLight Solutions!</p>
       <p>By following this Commitment Agreement, GreenLight hopes to create an experience that is beneficial, productive, and enjoyable for all involved that promotes the study and practice of cooperative sustainability research and application. In our collaboration, GreenLight Solutioneers shall strive to be involved, committed, honest, respectful, enthusiastic, adaptable, and supportive of each other and our ideas. Solutioneers shall be professional and respectful in communicating and promoting each other, ourselves, peers, mentors, stakeholders, and the field of sustainability science. Failure to meet the agreements below may be terms for removal from your GreenLight Solutions chapter as determined by your Leadership Team and Faculty Advisor.</p>
@@ -27,7 +27,7 @@
         <li>work my hardest to strengthen our organization’s integrity and help us grow sustainably!</li>
       </ul>
       <p>GreenLight Solutions provides a fun and unique way to grow yourself personally and professionally. Just like with anything in life, the opportunity is what you make of it! Get involved, get activated, and do your very best to create sustainable solutions for your local community! By signing your name below, you are committing to the agreements herein and agree to join our movement of advancing sustainable business model evolution.</p>
-  
+
       <form-error v-if="errorMessage">{{ errorMessage }}</form-error>
       <agreement-signature-form :name="commitmentAgreement.name" :date="commitmentAgreement.date" :onSubmit="doContinue" :errorMessage="errorMessage">
       </agreement-signature-form>
@@ -46,10 +46,17 @@ export default {
     AgreementSignatureForm,
     FormError,
   },
+  mounted() {
+    if (this.user.commitmentAgreementSigned) this.$router.replace({ name: 'solutioneering-101' });
+  },
   data() {
     return {
       errorMessage: '',
     };
+  },
+  computed: {
+    ...mapState('onboarding', ['commitmentAgreement']),
+    ...mapState('authentication', ['user']),
   },
   methods: {
     ...mapActions('onboarding', ['signCommitmentAgreement']),
@@ -64,9 +71,6 @@ export default {
         })
         .catch((err) => { this.errorMessage = err; });
     },
-  },
-  computed: {
-    ...mapState('onboarding', ['commitmentAgreement']),
   },
 };
 </script>

--- a/src/pages/ConfidentialityAgreement.vue
+++ b/src/pages/ConfidentialityAgreement.vue
@@ -4,9 +4,9 @@
       <md-card-header-text>
         <div class="md-title">Confidentiality Policy</div>
       </md-card-header-text>
-  
+
     </md-card-header>
-  
+
     <md-card-content>
       <p>GreenLight Solutions Foundation (“Corporation”) recognizes that efficient operation requires the maintenance and management of extensive Confidential Information related to its programs as well as donor and prospect records. The purpose of this Confidentiality Policy (“Policy”) is to memorialize the Corporation’s position on confidentiality.</p>
       <p>The Corporation is working to create educational opportunities for university students, as well as community and business organizations, by engaging them in applied projects based upon leading sustainability research and practices to create strategic solutions (“Mission”). The Corporation considers certain information related to the Mission to be “Confidential Information”. Such Confidential Information includes, but is not limited to, the following:</p>
@@ -46,7 +46,7 @@
         <strong>H. Public Disclosure.</strong> The Corporation will comply with both the letter and spirit of all public disclosure requirements, including the open availability of its Form 990 tax returns. This policy shall not be construed in any manner so as to prevent the Corporation from disclosing information to taxing authorities or other governmental agencies or courts having regulatory control or jurisdiction over the Corporation. However, all staff, volunteers, and consultants must hold strictly confidential all issues of a private nature, including, but not limited to, all issues explicitly discussed in this policy.</p>
       <p>
         <strong>I. Consequences of Policy Violation.</strong> Violations of the Policy are considered very serious, and may result in disciplinary action up to and including dismissal for employees or consultants or removal from the Board or any committee for volunteers.</p>
-  
+
       <h1 class="md-title">Confidentiality Agreement</h1>
       <p>By signing below, I acknowledge that:</p>
       <ol>
@@ -55,7 +55,7 @@
         <li>I agree to abide by this Policy to the best of my ability in my role as a director, officer, volunteer, consultant or employee.</li>
       </ol>
       <p>I acknowledge and agree that I will not disclose any Confidential Information, in whatever form to unauthorized parties. I agree that at the end of my relationship with the Corporation, I will destroy or return to the Corporation all Records containing Confidential Information in my possession or control regardless of how stored or maintained, including all originals, copies and compilations and all information stored or maintained on computer, tapes, discs, E-mail or any other form of technology.</p>
-  
+
       <form-error v-if="errorMessage">{{ errorMessage }}</form-error>
       <agreement-signature-form :name="confidentialityAgreement.name" :date="confidentialityAgreement.date" :onSubmit="doContinue" :errorMessage="errorMessage">
       </agreement-signature-form>
@@ -70,14 +70,21 @@ import FormError from '../components/FormError.vue';
 
 export default {
   name: 'confidentiality-agreement',
+  components: {
+    AgreementSignatureForm,
+    FormError,
+  },
+  mounted() {
+    if (this.user.ndaSigned) this.$router.replace({ name: 'commitment-agreement' });
+  },
   data() {
     return {
       errorMessage: '',
     };
   },
-  components: {
-    AgreementSignatureForm,
-    FormError,
+  computed: {
+    ...mapState('onboarding', ['confidentialityAgreement']),
+    ...mapState('authentication', ['user']),
   },
   methods: {
     ...mapActions('onboarding', ['signConfidentialityAgreement']),
@@ -93,9 +100,6 @@ export default {
         })
         .catch((err) => { this.errorMessage = err; });
     },
-  },
-  computed: {
-    ...mapState('onboarding', ['confidentialityAgreement']),
   },
 };
 </script>

--- a/src/pages/ConfidentialityAgreement.vue
+++ b/src/pages/ConfidentialityAgreement.vue
@@ -74,7 +74,7 @@ export default {
     AgreementSignatureForm,
     FormError,
   },
-  mounted() {
+  created() {
     if (this.user.ndaSigned) this.$router.replace({ name: 'commitment-agreement' });
   },
   data() {

--- a/src/pages/Dashboard.vue
+++ b/src/pages/Dashboard.vue
@@ -53,6 +53,13 @@
       ProjectDetails,
       WelcomeDialog,
     },
+    mounted() {
+      if (!this.user.isOnboarded) {
+        this.isWelcomeOpen = true;
+      } else if (this.$route.params.showDialog && this.$route.params.showDialog === 'solutioneerCongrats') {
+        this.$refs.congratsDialog.open();
+      }
+    },
     data: () => ({
       isWelcomeOpen: false,
       selectedProjects: [
@@ -112,13 +119,6 @@
         this.$refs.congratsDialog.close();
         this.$router.push({ name: 'project-selections' });
       },
-    },
-    mounted() {
-      if (!this.user.isOnboarded) {
-        this.isWelcomeOpen = true;
-      } else if (this.$route.params.showDialog && this.$route.params.showDialog === 'solutioneerCongrats') {
-        this.$refs.congratsDialog.open();
-      }
     },
   };
 </script>

--- a/src/pages/Dashboard.vue
+++ b/src/pages/Dashboard.vue
@@ -99,7 +99,7 @@
       ],
     }),
     computed: {
-      ...mapState('onboarding', ['solutioneering101Quiz']),
+      ...mapState('authentication', ['user']),
     },
     methods: {
       doGetStarted() {
@@ -114,7 +114,7 @@
       },
     },
     mounted() {
-      if (!this.solutioneering101Quiz.complete) {
+      if (!this.user.isOnboarded) {
         this.isWelcomeOpen = true;
       } else if (this.$route.params.showDialog && this.$route.params.showDialog === 'solutioneerCongrats') {
         this.$refs.congratsDialog.open();

--- a/src/pages/Dashboard.vue
+++ b/src/pages/Dashboard.vue
@@ -6,14 +6,14 @@
     <div class="section-container">
       <div class="page-heading">My Projects</div>
 
-      <div v-if="user.assignedProjects && user.assignedProjects.length > 0">
-        <project-details v-for="project in user.assignedProjects" :key="project.id" :project="project"></project-details>
+      <div v-if="assignedProjects && assignedProjects.length > 0">
+        <project-details v-for="project in assignedProjects" :key="project.id" :project="project"></project-details>
       </div>
 
-      <div v-else-if="user.selectedProjects && user.selectedProjects.length > 0">
+      <div v-else-if="selectedProjects && selectedProjects.length > 0">
         <p>Your project application is pending.  Your project picks were:</p>
         <div id="project-selections">
-          <project-summary v-for="project in user.selectedProjects" :key="project.id" :project="project"></project-summary>
+          <project-summary v-for="project in selectedProjects" :key="project.id" :project="project"></project-summary>
         </div>
         <p>You will receive an e-mail once you've been added to a project.</p>
       </div>
@@ -53,55 +53,51 @@
       ProjectDetails,
       WelcomeDialog,
     },
-    data() {
-      return {
-        isWelcomeOpen: false,
-        user: {
-          selectedProjects: [
-            {
-              id: 1,
-              name: 'Build Us Hope',
-              partnerOrganization: {
-                name: 'Singleton Community Services, INC.',
-                logo: 'https://placehold.it/70x70?text=logo',
-              },
-            },
-            {
-              id: 2,
-              name: 'Shaw Montessori Project',
-              partnerOrganization: {
-                name: 'Augustus H. Shaw Jr. Elementary School',
-                logo: 'https://placehold.it/70x70?text=logo',
-              },
-            },
-            {
-              id: 3,
-              name: 'Solar Impact in the Valley of the Sun',
-              partnerOrganization: {
-                name: 'SolarCity',
-                logo: 'https://placehold.it/70x70?text=logo',
-              },
-            },
-          ],
-          assignedProjects: [
-            {
-              id: 1,
-              name: 'Build Us Hope',
-              description: 'Design and build an affordable and sustainable tiny home community.',
-              partnerOrganization: {
-                name: 'Singleton Community Services, INC.',
-                logo: 'https://placehold.it/70x70?text=logo',
-              },
-              enrolledPositions: 5, // not in project model
-              totalPositions: 10,
-              startDate: '8/15/2017',
-              endDate: '12/14/2017',
-              resourcesUrl: 'https://drive.google.com/drive/folders/0B1FoB345Ur60ckxIa0dlYW1asdflE?usp=sharing', // not in project model
-            },
-          ],
+    data: () => ({
+      isWelcomeOpen: false,
+      selectedProjects: [
+        {
+          id: 1,
+          name: 'Build Us Hope',
+          partnerOrganization: {
+            name: 'Singleton Community Services, INC.',
+            logo: 'https://placehold.it/70x70?text=logo',
+          },
         },
-      };
-    },
+        {
+          id: 2,
+          name: 'Shaw Montessori Project',
+          partnerOrganization: {
+            name: 'Augustus H. Shaw Jr. Elementary School',
+            logo: 'https://placehold.it/70x70?text=logo',
+          },
+        },
+        {
+          id: 3,
+          name: 'Solar Impact in the Valley of the Sun',
+          partnerOrganization: {
+            name: 'SolarCity',
+            logo: 'https://placehold.it/70x70?text=logo',
+          },
+        },
+      ],
+      assignedProjects: [
+        {
+          id: 1,
+          name: 'Build Us Hope',
+          description: 'Design and build an affordable and sustainable tiny home community.',
+          partnerOrganization: {
+            name: 'Singleton Community Services, INC.',
+            logo: 'https://placehold.it/70x70?text=logo',
+          },
+          enrolledPositions: 5, // not in project model
+          totalPositions: 10,
+          startDate: '8/15/2017',
+          endDate: '12/14/2017',
+          resourcesUrl: 'https://drive.google.com/drive/folders/0B1FoB345Ur60ckxIa0dlYW1asdflE?usp=sharing', // not in project model
+        },
+      ],
+    }),
     computed: {
       ...mapState('onboarding', ['solutioneering101Quiz']),
     },

--- a/src/pages/Login.vue
+++ b/src/pages/Login.vue
@@ -39,6 +39,7 @@
     data() {
       return {
         mode: 'login',
+        pending: false,
         email: '',
         password: '',
         passwordConfirm: '',
@@ -65,7 +66,7 @@
       return null;
     },
     computed: {
-      ...mapState('authentication', ['pending', 'errorMessage']),
+      ...mapState('authentication', ['errorMessage']),
       ...mapGetters('authentication', ['isAuthenticated']),
     },
     methods: {
@@ -80,15 +81,19 @@
         this[field] = value;
       },
       doLogin(fields) {
+        this.pending = true;
         this.login(fields).then((user) => {
-          if (user === null) return this.$router.push({ name: 'approval-pending' });
+          this.pending = false;
+          if (user == null) return this.$router.push({ name: 'approval-pending' });
           return this.$router.push(this.sendTo);
-        });
+        }).catch(() => (this.pending = false));
       },
       doSignup(fields) {
+        this.pending = true;
         this.signup(fields).then((user) => {
-          if (user === null) this.$router.push({ name: 'approval-pending' });
-        });
+          this.pending = false;
+          if (user == null) this.$router.push({ name: 'approval-pending' });
+        }).catch(() => (this.pending = false));
       },
     },
   };

--- a/src/pages/Solutioneering101.vue
+++ b/src/pages/Solutioneering101.vue
@@ -21,7 +21,7 @@
 
   export default {
     name: 'solutioneering-101',
-    mounted() {
+    created() {
       if (this.user.solutioneer101Passed) this.$router.replace({ name: 'dashboard' });
     },
     computed: {

--- a/src/pages/Solutioneering101.vue
+++ b/src/pages/Solutioneering101.vue
@@ -17,8 +17,16 @@
 </template>
 
 <script>
+  import { mapState } from 'vuex';
+
   export default {
     name: 'solutioneering-101',
+    mounted() {
+      if (this.user.solutioneer101Passed) this.$router.replace({ name: 'dashboard' });
+    },
+    computed: {
+      ...mapState('authentication', ['user']),
+    },
     methods: {
       doContinue() {
         this.$router.push({ name: 'solutioneering-101-quiz' });

--- a/src/services/user.js
+++ b/src/services/user.js
@@ -1,4 +1,4 @@
-import User, { wrapUser } from '../models/user';
+import User from '../models/user';
 import Member from '../models/member';
 
 export function login(username, password) {
@@ -73,10 +73,7 @@ export function logout() {
 }
 
 export function getCurrent() {
-  const currentUser = User.getCurrent();
-
-  if (currentUser) return Promise.resolve(wrapUser(currentUser));
-  return Promise.resolve(null);
+  return User.getCurrent();
 }
 
 export function getUser(user) {

--- a/src/store/authentication.js
+++ b/src/store/authentication.js
@@ -10,7 +10,7 @@ export default {
   },
   mutations: {
     setUser(state, user) {
-      state.user = user ? omit(user, ['access_token', 'token_type']) : user;
+      state.user = user;
     },
     resetUser(state) {
       state.user = null;

--- a/src/store/authentication.js
+++ b/src/store/authentication.js
@@ -1,4 +1,3 @@
-import { omit } from '../lib/utils';
 import { getCurrent, login, logout, create } from '../services/user';
 
 export default {
@@ -18,9 +17,6 @@ export default {
     setErrorMessage(state, msg) {
       state.errorMessage = msg;
     },
-    togglePending(state, pending = null) {
-      state.pending = (pending !== null) ? pending : !state.pending;
-    },
   },
   actions: {
     initialize({ commit }) {
@@ -37,11 +33,9 @@ export default {
 
       // clear error and set pending state
       commit('setErrorMessage', '');
-      commit('togglePending');
 
       return login(username, password)
       .then((user) => {
-        commit('togglePending');
         commit('setUser', user);
       })
       .catch((err) => {
@@ -49,7 +43,6 @@ export default {
         const { code, message } = err;
 
         // toggle pending state
-        commit('togglePending');
         if (!message) return commit('setErrorMessage', defaultMsg);
 
         // codes: http://docs.parseplatform.org/js/guide/#error-codes
@@ -64,17 +57,12 @@ export default {
     signup({ commit }, userDetails) {
       // clear error and set pending state
       commit('setErrorMessage', '');
-      commit('togglePending');
 
       return create(userDetails)
-      .then(() => {
-        commit('togglePending');
-        return {
-          username: userDetails.username,
-        };
-      })
+      .then(() => ({
+        username: userDetails.username,
+      }))
       .catch((err) => {
-        commit('togglePending');
         const defaultMsg = 'Signup failed, please try again';
         const { code, message } = err;
 

--- a/src/store/authentication.js
+++ b/src/store/authentication.js
@@ -37,6 +37,7 @@ export default {
       return login(username, password)
       .then((user) => {
         commit('setUser', user);
+        return user;
       })
       .catch((err) => {
         const defaultMsg = 'Login failed';


### PR DESCRIPTION
- When a user is not onboarded and the click on Get Started in the welcome modal, check each resulting page to see which part of the workflow they are on, and make sure aren't shown a page they already completed.
- When logging in, correctly send the user to the awaiting approval page based on the `currentlyActive` property (from the Member class)
- When logging in, and approved, correctly send the user to the dashboard