### PR TITLE
Clear add user form, fix list

### DIFF
--- a/src/components/AddUser.vue
+++ b/src/components/AddUser.vue
@@ -70,9 +70,8 @@
         this.$refs.addUser.close();
       },
       openDialog() {
+        this.reset();
         this.$refs.addUser.open();
-        this.email = '';
-        this.password = this.generatePassword();
       },
       generatePassword(len = 10) {
         let str = '';
@@ -94,9 +93,14 @@
           firstName: this.firstName,
           lastName: this.lastName,
         }).then(() => {
-          this.createPending = false;
-          this.$emit('create');
-          this.$emit('close');
+          // build in some additional delay to let parse catch up...
+          const delay = 100;
+          setTimeout(() => {
+            this.createPending = false;
+            this.$emit('create');
+            this.$emit('close');
+            this.reset();
+          }, delay);
         }).catch((err) => {
           this.createPending = false;
           this.alert = err.message;
@@ -106,6 +110,13 @@
         if (!this.username.length) {
           this.username = this.email.split('@')[0].replace(/[^a-zA-Z0-9]/, '');
         }
+      },
+      reset() {
+        this.email = '';
+        this.username = '';
+        this.firstName = '';
+        this.lastName = '';
+        this.password = this.generatePassword();
       },
     },
     watch: {

--- a/src/pages/admin/MemberList.vue
+++ b/src/pages/admin/MemberList.vue
@@ -1,7 +1,7 @@
 <template>
   <div>
     <!-- add user dialog -->
-    <add-user :is-open="showAddUser" @close="closeAddUser" @create="refreshMembers"></add-user>
+    <add-user :is-open="showAddUser" @close="closeAddUser" @create="closeAddAndRefresh"></add-user>
     <edit-user :is-open="showEditUser" :user="selectedUser" @close="closeEditUser"></edit-user>
 
     <form @submit.prevent="refreshMembers">
@@ -185,6 +185,10 @@ export default {
     },
     closeAddUser() {
       this.showAddUser = false;
+    },
+    closeAddAndRefresh() {
+      this.closeAddUser();
+      this.refreshMembers();
     },
     openEditUser(member) {
       this.selectedUser = member;


### PR DESCRIPTION
When users are added, add a little extra delay, so that parse can catch up and return the correct list when it is refreshed